### PR TITLE
Add GitHub Actions workflows for large screen codelabs

### DIFF
--- a/.github/workflows/add-keyboard-and-mouse-support-with-compose-build-app.yml
+++ b/.github/workflows/add-keyboard-and-mouse-support-with-compose-build-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Add Keyboard and Mouse Support Codelab
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/add-keyboard-and-mouse-support-with-compose
+
+      - name: Build app
+        working-directory: ./large-screen-codelabs/add-keyboard-and-mouse-support-with-compose
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/advanced-stylus-end-build-app.yml
+++ b/.github/workflows/advanced-stylus-end-build-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Advanced Stylus Codelab - End
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/advanced-stylus/end
+
+      - name: Build app
+        working-directory: ./large-screen-codelabs/advanced-stylus/end
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/advanced-stylus-start-build-app.yml
+++ b/.github/workflows/advanced-stylus-start-build-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Advanced Stylus Codelab - Start
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/advanced-stylus/start
+
+      - name: Build app
+        working-directory: ./large-screen-codelabs/advanced-stylus/start
+        run: ./gradlew :app:assembleDebug

--- a/.github/workflows/android-camera-foldables-build-step1.yml
+++ b/.github/workflows/android-camera-foldables-build-step1.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Android Camera Foldables Codelab - Step 1
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/android-camera-foldables
+
+      - name: Build step1 app
+        working-directory: ./large-screen-codelabs/android-camera-foldables
+        run: ./gradlew :step1:assembleDebug

--- a/.github/workflows/android-camera-foldables-build-step2.yml
+++ b/.github/workflows/android-camera-foldables-build-step2.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Android Camera Foldables Codelab - Step 2
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/android-camera-foldables
+
+      - name: Build step2 app
+        working-directory: ./large-screen-codelabs/android-camera-foldables
+        run: ./gradlew :step2:assembleDebug

--- a/.github/workflows/focus-management-in-compose-build-solution.yml
+++ b/.github/workflows/focus-management-in-compose-build-solution.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Focus Management Codelab - Solution
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/focus-management-in-compose
+
+      - name: Build solution app
+        working-directory: ./large-screen-codelabs/focus-management-in-compose
+        run: ./gradlew :solution:assembleDebug

--- a/.github/workflows/focus-management-in-compose-build-start.yml
+++ b/.github/workflows/focus-management-in-compose-build-start.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Focus Management Codelab - Start
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./large-screen-codelabs/focus-management-in-compose
+
+      - name: Build start app
+        working-directory: ./large-screen-codelabs/focus-management-in-compose
+        run: ./gradlew :start:assembleDebug


### PR DESCRIPTION
This commit adds new GitHub Actions workflows to automate the building of several large screen codelabs.

The workflows are defined in `.github/workflows/` and are triggered on:

-   `workflow_dispatch`
-   `push` events to the `main` branch
-   `pull_request` events targeting the `main` branch

The workflows perform the following steps:

-   Checkout the code
-   Set up JDK 17
-   Set up Gradle
-   Make `gradlew` executable
-   Build the app using `./gradlew :app:assembleDebug` or a similar
    command, depending on the codelab's module structure.

The following workflows have been added:

-   `add-keyboard-and-mouse-support-with-compose-build-app.yml`
    (Add Keyboard and Mouse Support Codelab)
-   `advanced-stylus-end-build-app.yml` (Advanced Stylus Codelab - End)
-   `advanced-stylus-start-build-app.yml` (Advanced Stylus Codelab -
    Start)
-   `android-camera-foldables-build-step1.yml` (Android Camera
    Foldables Codelab - Step 1)
-   `android-camera-foldables-build-step2.yml` (Android Camera
    Foldables Codelab - Step 2)
-   `focus-management-in-compose-build-solution.yml` (Focus Management
    Codelab - Solution)
-   `focus-management-in-compose-build-start.yml` (Focus Management
    Codelab - Start)